### PR TITLE
feat: protect `/slice-simulator` with an optional secret

### DIFF
--- a/src/app/slice-simulator/page.tsx
+++ b/src/app/slice-simulator/page.tsx
@@ -4,6 +4,7 @@ import {
   getSlices,
 } from "@slicemachine/adapter-next/simulator";
 import { SliceZone } from "@prismicio/react";
+import { redirect } from "next/navigation";
 
 import { components } from "@/slices";
 
@@ -14,7 +15,7 @@ export default function SliceSimulatorPage({
     process.env.SLICE_SIMULATOR_SECRET &&
     searchParams.secret !== process.env.SLICE_SIMULATOR_SECRET
   ) {
-    throw new Error("Incorrect or missing secret");
+    redirect("/");
   }
 
   const slices = getSlices(searchParams.state);

--- a/src/app/slice-simulator/page.tsx
+++ b/src/app/slice-simulator/page.tsx
@@ -9,7 +9,14 @@ import { components } from "@/slices";
 
 export default function SliceSimulatorPage({
   searchParams,
-}: SliceSimulatorParams) {
+}: SliceSimulatorParams & { searchParams: { secret?: string } }) {
+  if (
+    process.env.SLICE_SIMULATOR_SECRET &&
+    searchParams.secret !== process.env.SLICE_SIMULATOR_SECRET
+  ) {
+    throw new Error("Incorrect or missing secret");
+  }
+
   const slices = getSlices(searchParams.state);
 
   return (


### PR DESCRIPTION
This PR adds optional protection to the `/slice-simulator` route.

Prismic recommends protecting the `/slice-simulator` route in production.

## How to protect the `/slice-simulator` route

Follow these steps to protect the `/slice-simulator` route:

1. Add a `SLICE_SIMULATOR_SECRET` [environment variable](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables). The value should be unique and unguessable.
2. Update the [live preview URL](https://prismic.io/docs/page-builder#enable-live-previews) in the Prismic Page Builder to include `?secret=<your-secret>`.

   Example: `https://example.com/slice-simulator?secret=my-secret`

Now, if the `secret` URL parameter does not match the `SLICE_SIMULATOR_SECRET` environment variable, the request is redirected to `/`.

The `/slice-simulator` route will accept any request if the `SLICE_SIMULATOR_SECRET` environment variable is not set.